### PR TITLE
Update child theme enqueue list

### DIFF
--- a/Child Theme/README.md
+++ b/Child Theme/README.md
@@ -1,0 +1,16 @@
+# Brandon Child Theme Enqueue List
+
+This child theme relies on the GSAP installation that ships with Semplice.
+Only additional libraries needed by the custom animations are loaded.
+
+## Enqueued Assets
+
+- **brandon-custom-styles** – `style.css`
+- **brandon-p5** – `p5.js` v1.9.4
+- **brandon-gsap-ce** – GSAP `CustomEase` plugin v3.13.0
+- **brandon-custom-scripts** – `brandon-custom-scripts.js`
+  - Depends on `brandon-p5` and `brandon-gsap-ce`
+  - Runs after Semplice’s core scripts (hook priority `20`)
+
+GSAP core and other plugins are provided by the parent theme and are
+not enqueued here.

--- a/Child Theme/functions.php
+++ b/Child Theme/functions.php
@@ -40,14 +40,6 @@ function brandon_enqueue_custom_scripts() {
         );
 
         // --- THIRD-PARTY LIBRARIES ---
-        // Core GSAP
-        wp_enqueue_script(
-            'gsap-core',
-            'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.13.0/gsap.min.js',
-            array(),
-            '3.13.0',
-            true
-        );
 
         // P5.js
         wp_enqueue_script(
@@ -62,34 +54,18 @@ function brandon_enqueue_custom_scripts() {
         wp_enqueue_script(
             'brandon-gsap-ce',
             'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.13.0/CustomEase.min.js',
-            array('gsap-core'),
+            array(),
             '3.13.0',
             true
         );
 
-        wp_enqueue_script(
-            'brandon-gsap-st',
-            'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.13.0/ScrollTrigger.min.js',
-            array('gsap-core'),
-            '3.13.0',
-            true
-        );
 
-        // ---- [NEW] GSAP SplitText Plugin ----
-        wp_enqueue_script(
-            'brandon-gsap-splittext',
-            'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.13.0/SplitText.min.js',
-            array('gsap-core'),
-            '3.13.0',
-            true
-        );
-        // ---- [END NEW] ----
 
         // --- CUSTOM JS ---
         wp_enqueue_script(
             'brandon-custom-scripts',
             get_stylesheet_directory_uri() . '/brandon-custom-scripts.js',
-            array('gsap-core', 'brandon-p5', 'brandon-gsap-ce', 'brandon-gsap-st', 'brandon-gsap-splittext'),
+            array('brandon-p5', 'brandon-gsap-ce'),
             '1.0.3',
             true
         );
@@ -99,4 +75,4 @@ function brandon_enqueue_custom_scripts() {
     }
 }
 
-add_action( 'wp_enqueue_scripts', 'brandon_enqueue_custom_scripts' );
+add_action( 'wp_enqueue_scripts', 'brandon_enqueue_custom_scripts', 20 );


### PR DESCRIPTION
## Summary
- trim child theme enqueued scripts to rely on Semplice's built-in GSAP
- add README describing the remaining assets

## Testing
- `php -l Child\ Theme/functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522961ab8c83319f62066f3c1699be