### PR TITLE
Add clickable menu trigger styling

### DIFF
--- a/Child Theme/style.css
+++ b/Child Theme/style.css
@@ -197,21 +197,29 @@
 
 /* ========== BRANDON NAMESPACE: DOTS GRID MENU ICON ========== */
 .brandon-dots-grid {
-	position: relative;
-	width: 24px;
-	height: 24px;
-	display: flex;
-	align-items: center;
+        position: relative;
+        width: 24px;
+        height: 24px;
+        display: flex;
+        align-items: center;
     justify-content: center;
 }
 
 .brandon-dots-grid .brandon-dot {
-	position: absolute;
-	width: 4px;
-	height: 4px;
-	background-color: var(--brandon-dot-color);
-	border-radius: 50%;
-	transform-origin: center center;
+        position: absolute;
+        width: 4px;
+        height: 4px;
+        background-color: var(--brandon-dot-color);
+        border-radius: 50%;
+        transform-origin: center center;
+}
+
+/* Clickable wrapper for the grid icon */
+.brandon-dots-grid-trigger {
+        display: inline-block;
+        cursor: pointer;
+        width: 24px;
+        height: 24px;
 }
 
 


### PR DESCRIPTION
## Summary
- style the dots menu trigger so it behaves like a clickable icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68527b9e743883318da57fac539c3d7f