### PR TITLE
Wrap error log with debug check

### DIFF
--- a/Child Theme/functions.php
+++ b/Child Theme/functions.php
@@ -5,7 +5,9 @@
  * Enqueues all custom and third-party scripts for the front-end only.
  */
 
-error_log('=== FUNCTIONS.PHP LOADED ===');
+if (defined('WP_DEBUG') && WP_DEBUG) {
+    error_log('=== FUNCTIONS.PHP LOADED ===');
+}
 
 // Prevent direct access
 if (!defined('ABSPATH')) {


### PR DESCRIPTION
## Summary
- log `=== FUNCTIONS.PHP LOADED ===` only when `WP_DEBUG` is enabled

## Testing
- `php -l 'Child Theme/functions.php'` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68527ba02c2883318ab6386a37fca9e9